### PR TITLE
feat: userpage automatically populates with summary of logged in user…

### DIFF
--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -1,7 +1,12 @@
 
 import React from "react"
 import { Route } from "react-router-dom"
-import { UserPage } from "./routes/users/UserPage"
+import { UserPage } from "./routes/userPages/UserPage"
+import { MoveProvider } from "./moves/MoveProvider"
+import { BoxProvider } from "./boxes/BoxProvider"
+import { ItemProvider } from "./items/ItemProvider"
+
+
 // import { Home } from "./Home"
 
 // import { CustomerList } from "./customer/CustomerList"
@@ -26,9 +31,11 @@ import { UserPage } from "./routes/users/UserPage"
 export const ApplicationViews = () => {
  return (
   <>
-    {/* <Route exact path="/users">
-      <UserPage />
-    </Route> */}
+    <Route exact path="/users">
+      <MoveProvider><BoxProvider><ItemProvider>
+        <UserPage />
+      </ItemProvider></BoxProvider></MoveProvider>
+    </Route>
 
    {/* Render the animal list when http://localhost:3000/locations */}
    {/* <LocationProvider> */}

--- a/src/components/PackItUp.jsx
+++ b/src/components/PackItUp.jsx
@@ -6,7 +6,7 @@ import { Register } from "./auth/Register";
 
 import { ApplicationViews } from "./ApplicationViews";
 import { LandingPage } from "./routes/landingPage/LandingPage"
-import { UserPage } from "./routes/users/UserPage";
+import { UserPage } from "./routes/userPages/UserPage";
 
 export const PackItUp = () => (
   <>
@@ -16,7 +16,8 @@ export const PackItUp = () => (
    return (
     <>
     { /* Components that are rendered when the user is authenticated go inside this React fragment */}
-    <UserPage />
+    {/* <UserPage /> */}
+    <ApplicationViews />
     </>
    )
   } else {

--- a/src/components/routes/userPages/UserPage.jsx
+++ b/src/components/routes/userPages/UserPage.jsx
@@ -1,11 +1,14 @@
 import React from "react"
+import { SummaryList } from "../../summary/SummaryList"
+import "./userPage.css"
 
 export const UserPage = () => {
  const loggedInUserId = parseInt(sessionStorage.getItem("app_user_id"))
+
  return (
   <main className="userPage">
-   <header className="userPage__header">PackItUp: { loggedInUserId }</header>
-   <section className="userPage__summary"></section>
+   <h1 className="userPage__header">PackItUp</h1>
+   <SummaryList loggedInUserId={loggedInUserId} />
    <button className="userPage__btn--logout">Logout</button>
   </main>
  )

--- a/src/components/routes/userPages/userPage.css
+++ b/src/components/routes/userPages/userPage.css
@@ -1,0 +1,40 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  /* border: 1px solid red; */
+}
+
+.userPage {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.userPage,
+.userPage__header,
+.userPage__btn--logout {
+  padding: 1em;
+}
+
+.userPage__header,
+.userPage__btn--logout {
+  text-align: center;
+}
+
+.userPage__btn--logout {
+  display: block;
+  /* margin: 10px auto; */
+  width: 50%;
+  border: 2px solid blue;
+  border-radius: 10px;
+}

--- a/src/components/summary/Summary.jsx
+++ b/src/components/summary/Summary.jsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+import "./summary.css"
+
+
+export const Summary = ({ data } ) => {
+
+ return (
+  <section className="summary">
+   <div className="summary__dataLength">{ data.collection.length }</div>
+   <div className="summary__buttons">
+    <h2 className="summary__moveType">{ data.type }</h2>
+    <Link to="/"><button className="summary__linkBtn--view" >View</button></Link>
+    <Link to="/"><button className="summary__linkBtn--edit" >Edit</button></Link>
+    <Link to="/"><button className="summary__linkBtn--delete" >Delete</button></Link>
+   </div>
+  </section>
+ )
+}

--- a/src/components/summary/SummaryList.jsx
+++ b/src/components/summary/SummaryList.jsx
@@ -1,0 +1,49 @@
+import React, { useContext, useEffect } from "react"
+
+import { MoveContext } from "../moves/MoveProvider"
+import { BoxContext } from "../boxes/BoxProvider"
+import { ItemContext } from "../items/ItemProvider"
+import { Summary } from "./Summary"
+import "./summaryList.css"
+
+
+export const SummaryList = ({ loggedInUserId }) => {
+
+ const { moves, getMoves } = useContext(MoveContext)
+ const { boxes, getBoxes } = useContext(BoxContext)
+ const { items, getItems } = useContext(ItemContext)
+
+ useEffect(() => {
+  getMoves()
+    .then(getBoxes)
+    .then(getItems)
+ }, []) // useEffect
+
+ 
+  const movesData = {
+    type: "moves",
+    collection: moves.filter(move => move.userId === loggedInUserId)
+  }
+
+  const boxesData = {
+    type: "boxes",
+    collection: boxes.filter(box => movesData.collection.find(move => box.moveId === move.id))
+  }
+
+  const itemsData = {
+    type: "items",
+    collection: items.filter(item => boxesData.collection.find(box => item.boxId === box.id))
+  }
+  
+  const loggedInUserName = moves.find(move => move.userId === loggedInUserId)
+  const dataToRender = [movesData, boxesData, itemsData]
+
+  return (
+    <div className="summaryList">
+      <h1 className="summaryList__header">{ loggedInUserName?.user.username }'s Summary</h1>
+      {
+        dataToRender.map((payload, i) => <Summary key={i} data={payload} />)
+      }
+    </div>
+  )
+}

--- a/src/components/summary/summary.css
+++ b/src/components/summary/summary.css
@@ -1,0 +1,48 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  border: 1px solid blue;
+}
+
+.summary {
+  border: 2px solid blue;
+  display: flex;
+  background: orange;
+  text-align: center;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+
+.summary__dataLength {
+  padding: 1em;
+  background: lightgreen;
+  width: 20%;
+  text-align: center;
+}
+
+.summary__buttons {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.summary__moveType {
+  width: 100%;
+  display: block;
+  background: red;
+}
+
+.summary__linkBtn--view,
+.summary__linkBtn--edit,
+.summary__linkBtn--delete {
+  background: yellow;
+  padding: 1em;
+  margin: 0 10px;
+}

--- a/src/components/summary/summaryList.css
+++ b/src/components/summary/summaryList.css
@@ -11,3 +11,13 @@
 
   /* border: 1px solid red; */
 }
+
+.summaryList {
+  /* border: 2px solid red; */
+  padding: 1em;
+}
+.summaryList__header {
+  text-align: center;
+  color: red;
+  margin-bottom: 50px;
+}


### PR DESCRIPTION
# Description

After user registers/logs in, they are taken to their user page with a quick summery of how many moves, boxes, items they have.

Fixes #21 
Closes #21 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout cr-db-user-summary`
`npm start`

In another tab, cd into `api` and run

`json-server -p 8088 -w database.json`

1. Log in with existing user email.
2. After logging in, user will be redirected to their summary page.
3. Summary will display number of moves, boxes, items  and links to view, edit, delete.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works
	
