### PR TITLE
Cr navigation list views

### DIFF
--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -5,38 +5,38 @@ import { UserPage } from "./routes/userPages/UserPage"
 import { MoveProvider } from "./moves/MoveProvider"
 import { BoxProvider } from "./boxes/BoxProvider"
 import { ItemProvider } from "./items/ItemProvider"
+import { ItemList } from "./items/ItemList"
+import { BoxList } from "./boxes/BoxList"
+import { MoveList } from "./moves/MoveList"
 
 
 // import { Home } from "./Home"
 
-// import { CustomerList } from "./customer/CustomerList"
-// import { CustomerProvider } from "./customer/CustomerProvider"
-
-// import { AnimalList } from "./animal/AnimalList"
-// import { AnimalForm } from "./animal/AnimalForm"
-// import { AnimalDetail } from "./animal/AnimalDetail"
-// import { AnimalProvider } from "./animal/AnimalProvider"
-
-// import { EmployeeList } from "./employee/EmployeeList"
-// import { EmployeeForm } from "./employee/EmployeeForm"
-// import { EmployeeDetail } from "./employee/EmployeeDetail"
-// import { EmployeeProvider } from "./employee/EmployeeProvider"
-
-// import { LocationList } from "./location/LocationList"
-// import { LocationProvider } from "./location/LocationProvider"
-// import { LocationForm } from "./location/LocationForm"
-// import { LocationDetail } from "./location/LocationDetail"
-
-
 export const ApplicationViews = () => {
  return (
   <>
+  <MoveProvider><BoxProvider><ItemProvider>
     <Route exact path="/users">
-      <MoveProvider><BoxProvider><ItemProvider>
         <UserPage />
-      </ItemProvider></BoxProvider></MoveProvider>
     </Route>
 
+    <Route exact path="/items">
+        <ItemList />
+    </Route>
+
+    <Route exact path="/boxes">
+        <BoxList />
+    </Route>
+
+    <Route exact path="/moves">
+        <MoveList />
+    </Route>
+
+    {/* <Route path="/lists/:listType(\w+)/:userId(\d+)">
+        <ItemList />
+    </Route> */}
+  
+  </ItemProvider></BoxProvider></MoveProvider>
    {/* Render the animal list when http://localhost:3000/locations */}
    {/* <LocationProvider> */}
     {/* <Route exact path="/locations"> */}

--- a/src/components/boxes/BoxList.jsx
+++ b/src/components/boxes/BoxList.jsx
@@ -1,0 +1,59 @@
+import React, { useContext, useEffect, useState } from "react"
+
+import { userStorageKey } from "../auth/authSettings"
+import { MoveContext } from "../moves/MoveProvider"
+import { BoxContext } from "./BoxProvider"
+import { ItemContext } from "../items/ItemProvider"
+import { BoxSummary } from "./BoxSummary"
+import "./boxList.css"
+
+
+const _getSum = ( valueList ) => {
+ /*
+  Using .reduce on list of objects results with incorrect sum values.
+ */
+
+ if(!valueList.length) return 0;
+
+ const numList = valueList.map(item => item.value)
+
+ return numList.reduce((acc, curr) => acc + curr, 0)
+}
+
+
+export const BoxList = () => {
+
+ const { moves, getMoves } = useContext(MoveContext)
+ const { boxes, getBoxes } = useContext(BoxContext)
+ const { items, getItems } = useContext(ItemContext)
+ const loggedInUserId = parseInt(sessionStorage.getItem(userStorageKey))
+
+
+ useEffect(() => {
+  getMoves()
+    .then(getBoxes)
+    .then(getItems)
+
+ }, []) // useEffect
+
+  const movesData = moves.filter(move => move.userId === loggedInUserId)
+  const boxesData = boxes.filter(box => movesData.find(move => box.moveId === move.id))
+  const itemsData = items.filter(item => boxesData.find(box => item.boxId === box.id))
+  const loggedInUserObj = moves.find(move => move.userId === loggedInUserId)
+
+  boxesData.forEach(box => {
+   box.totalCount = itemsData.filter(item => item.boxId === box.id).length
+   box.totalValue = _getSum(itemsData.filter(item => item.boxId === box.id ? item.value : 0))
+   box.isFragile = itemsData.some(item => item.isFragile ? true : false)
+   box.moveName = movesData.find(move => move.id === box.moveId).moveName
+  }) // boxes.forEach
+
+   return (
+    <div className="boxSummaryList">
+      <h1 className="boxSummaryList__header">{ loggedInUserObj?.user.username }'s Boxes</h1>
+      {
+        boxesData.map((box, i) => <BoxSummary key={i} box={ box } />)
+      }
+    </div>
+  )
+}

--- a/src/components/boxes/BoxSummary.jsx
+++ b/src/components/boxes/BoxSummary.jsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+import "./boxSummary.css"
+
+
+export const BoxSummary = ({ box } ) => {
+
+ return (
+  <section className="boxSummary">
+   <img className="boxSummary__image" src="https://images.unsplash.com/photo-1595079676601-f1adf5be5dee?ixlib=rb-1.2.1&ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&auto=format&fit=crop&w=750&q=80" alt="QR code place holder" />
+
+   <div className="boxMove">
+     <p>Move</p>
+     <div className="boxMoveName">{ box.moveName }</div>
+  </div>
+  <div className="location">
+     <p>Location</p>
+     <div className="location__text">{ box.location }</div>
+  </div>
+
+    <div className="boxValue">
+     <p>Value</p>
+     <div className="box__value">${ box.totalValue }</div>
+    </div>
+
+    <div className="count">
+     <div className="count__items">{ box.totalCount }</div>
+     <div>Items</div>
+    </div>
+  
+    <div className="lowerRow">
+
+    <div className="fragile">
+     <p>Fragile</p>
+     <div className="checkBox">{ box.isFragile ? "X" : ""}</div>
+    </div>
+     <Link to={`/boxes/${box.id}`}>
+      <button id={`btn--edit-${box.id}`} className="box__linkBtn--edit">Edit</button>
+     </Link>
+     <Link to="/">
+      <button id={`btn--delete-${box.id}`} className="box__linkBtn--delete">Delete</button>
+     </Link>
+    </div> 
+  </section>
+ )
+}

--- a/src/components/boxes/boxList.css
+++ b/src/components/boxes/boxList.css
@@ -1,0 +1,22 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  border: 1px solid blue;
+}
+
+.boxSummaryList {
+  padding: 0.5em;
+}
+
+.boxSummaryList__header {
+  background: blue;
+  text-align: center;
+}

--- a/src/components/boxes/boxSummary.css
+++ b/src/components/boxes/boxSummary.css
@@ -1,0 +1,104 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  border: 1px solid green;
+}
+
+.boxSummary {
+  border: 2px solid blue;
+  background: lightsalmon;
+  text-align: center;
+  margin-top: 10px;
+
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+}
+
+.boxSummary__image {
+  border: 1px solid green;
+  grid-column-start: 1;
+  grid-column-end: 3;
+  grid-row-start: 1;
+  grid-row-end: 4;
+
+  width: 100%;
+}
+
+.boxMove,
+.location,
+.boxValue,
+.lowerRow {
+  grid-column-start: 3;
+  grid-column-end: 6;
+}
+
+.boxMove,
+.location,
+.boxValue {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5em;
+}
+
+.count {
+  grid-column-start: 1;
+  grid-column-end: 3;
+  background: lightgreen;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.count__items {
+  background: white;
+  height: 20px;
+  width: 20px;
+  padding: 2px;
+}
+
+.lowerRow {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.fragile {
+  display: flx;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5em;
+  grid-column-start: 3;
+  grid-column-end: 4;
+}
+
+.checkBox {
+  height: 10px;
+  width: 10px;
+  background: white;
+  padding: 0.2em;
+}
+
+.box__linkBtn--edit,
+.box__linkBtn--delete {
+  padding: 0.2em;
+  width: 70px;
+}
+
+.box__linkBtn--edit {
+  background: lightgreen;
+}
+
+.box__linkBtn--delete {
+  margin-left: 1em;
+  background: salmon;
+}

--- a/src/components/items/ItemList.jsx
+++ b/src/components/items/ItemList.jsx
@@ -1,0 +1,54 @@
+import React, { useContext, useEffect, useState } from "react"
+
+import { userStorageKey } from "../auth/authSettings"
+import { MoveContext } from "../moves/MoveProvider"
+import { BoxContext } from "../boxes/BoxProvider"
+import { ItemContext } from "./ItemProvider"
+import { ItemSummary } from "./ItemSummary"
+import "./itemList.css"
+
+export const ItemList = () => {
+
+ const { moves, getMoves } = useContext(MoveContext)
+ const { boxes, getBoxes } = useContext(BoxContext)
+ const { items, getItems } = useContext(ItemContext)
+ const loggedInUserId = parseInt(sessionStorage.getItem(userStorageKey))
+
+
+ useEffect(() => {
+  getMoves()
+    .then(getBoxes)
+    .then(getItems)
+ }, []) // useEffect
+ 
+
+  const movesData = moves.filter(move => move.userId === loggedInUserId)
+  const boxesData = boxes.filter(box => movesData.find(move => box.moveId === move.id))
+  const itemsData = items.filter(item => boxesData.find(box => item.boxId === box.id))
+
+
+  itemsData.forEach(item => {
+   /*
+    Make it easier for presentation template,
+    add properties that shows if item has a box/move assigned since
+    items/boxes can be delinked from boxes/moves, respectivly.
+
+    item.hasAssociatedBox = item.boxId ? true : false
+    item.hasAssociatedMove = item?.box.moveId ? true : false
+    Neat way to turn number into a boolean
+   */
+   item.hasAssociatedBox = !!item.boxId
+   item.hasAssociatedMove = !!item?.box.moveId
+  })
+
+  const loggedInUserObj = moves.find(move => move.userId === loggedInUserId)
+// console.log(loggedInUserObj)
+   return (
+    <div className="itemSummaryList">
+      <h1 className="itemSummaryList__header">{ loggedInUserObj?.user.username }'s Items</h1>
+      {
+        itemsData.map((item, i) => <ItemSummary key={i} item={item} />)
+      }
+    </div>
+  )
+}

--- a/src/components/items/ItemSummary.jsx
+++ b/src/components/items/ItemSummary.jsx
@@ -1,0 +1,42 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+import "./itemSummary.css"
+
+
+export const ItemSummary = ({ item } ) => {
+
+ return (
+  <section className="itemSummary">
+   <img className="itemSummary__image" src="https://unsplash.com/photos/nP9WOiM41WE" alt="QR code place holder" />
+    <div className="move">
+     <p>Move</p>
+     <div className="checkBox">{ item.hasAssociatedMove ? "X" : ""}</div>
+    </div>
+    <div className="description">
+     <div>Description</div>
+     <div className="description__text">{ item.description.substring(0, 12) + " . ." }</div>
+    </div>
+    <div className="box">
+     <p>Box</p>
+     <div className="checkBox">{ item.hasAssociatedBox? "X" : ""}</div>
+    </div>
+    <div className="value">
+     <div>Value</div>
+     <div className="description__value">${ item.value ? item.value : "0.00" }</div>
+    </div>
+    <div className="fragile">
+     <p>Fragile</p>
+     <div className="checkBox">{ item.isFragile ? "X" : ""}</div>
+    </div>
+    <div className="summary__btns">
+     <Link to={`/items/${item.id}`}>
+      <button id={`btn--edit-${item.id}`} className="summary__linkBtn--edit">Edit</button>
+     </Link>
+     <Link to="/">
+      <button id={`btn--delete-${item.id}`} className="summary__linkBtn--delete">Delete</button>
+     </Link>
+    </div>
+  </section>
+ )
+}

--- a/src/components/items/itemList.css
+++ b/src/components/items/itemList.css
@@ -1,0 +1,22 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  /* border: 1px solid blue; */
+}
+
+.itemSummaryList {
+  padding: 0.5em;
+}
+
+.itemSummaryList__header {
+  background: red;
+  text-align: center;
+}

--- a/src/components/items/itemSummary.css
+++ b/src/components/items/itemSummary.css
@@ -1,0 +1,92 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  /* border: 1px solid blue; */
+}
+
+.itemSummary {
+  border: 2px solid blue;
+  background: lightsalmon;
+  text-align: center;
+  justify-content: space-between;
+  margin-top: 10px;
+
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+}
+
+.itemSummary__image {
+  border: 1px solid green;
+  grid-column-start: 1;
+  grid-column-end: 2;
+  grid-row-start: 1;
+  grid-row-end: 3;
+}
+
+.description,
+.value,
+.summary__btns {
+  grid-column-start: 3;
+  grid-column-end: 6;
+}
+
+.move,
+.box,
+.fragile {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5em;
+  grid-column-start: 2;
+  grid-column-end: 3;
+}
+
+.description,
+.value {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5em;
+  text-align: left;
+}
+
+.description__text,
+.description__value {
+  flex-basis: 60%;
+}
+
+.checkBox {
+  height: 10px;
+  width: 10px;
+  background: white;
+  padding: 0.2em;
+}
+
+.summary__btns {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.summary__linkBtn--edit,
+.summary__linkBtn--delete {
+  padding: 0.2em;
+  width: 80px;
+}
+
+.summary__linkBtn--edit {
+  background: lightgreen;
+}
+
+.summary__linkBtn--delete {
+  margin-left: 1em;
+  background: salmon;
+}

--- a/src/components/moves/MoveList.js
+++ b/src/components/moves/MoveList.js
@@ -1,0 +1,91 @@
+import React, { useContext, useEffect, useState } from "react"
+
+import { userStorageKey } from "../auth/authSettings"
+import { BoxContext } from "../boxes/BoxProvider"
+import { ItemContext } from "../items/ItemProvider"
+import { MoveContext } from "./MoveProvider"
+import { MoveSummary } from "./MoveSummary"
+import "./moveList.css"
+
+
+const _getSum = ( valueList ) => {
+ /*
+  Using .reduce on list of objects results with incorrect sum values.
+ */
+
+ if(!valueList.length) return 0;
+
+ const numList = valueList.map(item => item.value)
+
+ return numList.reduce((acc, curr) => acc + curr, 0)
+}
+
+const _getSum2 = ( valueList ) => {
+
+ if(!valueList.length) return 0;
+
+ return valueList.reduce((acc, curr) => acc + curr, 0)
+}
+
+
+export const MoveList = () => {
+
+ const { moves, getMoves } = useContext(MoveContext)
+ const { boxes, getBoxes } = useContext(BoxContext)
+ const { items, getItems } = useContext(ItemContext)
+ const loggedInUserId = parseInt(sessionStorage.getItem(userStorageKey))
+
+
+ useEffect(() => {
+  getMoves()
+    .then(getBoxes)
+    .then(getItems)
+
+ }, []) // useEffect
+
+  const movesData = moves.filter(move => move.userId === loggedInUserId)
+  const boxesData = boxes.filter(box => movesData.find(move => box.moveId === move.id))
+  const itemsData = items.filter(item => boxesData.find(box => item.boxId === box.id))
+  const loggedInUserObj = moves.find(move => move.userId === loggedInUserId)
+
+   movesData.forEach(move => {
+     /*
+      For each move
+        get the number of boxes associated with the move
+        for each box
+          get the total number of items in that box
+          update the number of total boxes for that move
+          get the total value of tims in that box
+          updatae the total number of items of rthat move
+     */
+    /*
+    TODO: find a way to make this _getSum generic wtih BoxList _getSum
+    TODO: instead of fetching objcts, only fetch ids
+    */
+    const boxesForThisMove = boxesData.filter(box => box.moveId === move.id)
+
+    move.totalBoxCount = boxesForThisMove.length
+    move.totalItemsCount = 0
+    move.totalItemsValue = 0
+
+    boxesForThisMove.forEach(box => {
+      move.totalItemsCount += itemsData.filter(item => item.boxId === box.id).length
+      move.totalItemsValue += _getSum(itemsData.filter(item => item.boxId === box.id ? item.value : 0))
+      box.isFragile = itemsData.some(item => item.isFragile ? true : false)
+    }) // boxes.forEach
+
+    const anyFragile = boxesForThisMove.map(b => b.isFragile).some(f => f ? f : !f)
+    move.isFragile = anyFragile
+  }) // moves.forEach
+
+
+   return (
+    <div className="moveSummaryList">
+      <h1 className="moveSummaryList__header">{ loggedInUserObj?.user.username }'s Moves</h1>
+      {
+        movesData.map((move, i) => <MoveSummary key={i} move={ move } />)
+      }
+      cows
+    </div>
+  )
+}

--- a/src/components/moves/MoveSummary.js
+++ b/src/components/moves/MoveSummary.js
@@ -1,0 +1,43 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+import "./moveSummary.css"
+
+
+export const MoveSummary = ({ move } ) => {
+
+ return (
+  <section className="moveSummary">
+    <div className="boxCount">
+     <div className="boxCount__count">{ move.totalBoxCount }</div>
+     <div>Boxes</div>
+    </div>
+    <div className="moveName">
+      <p>Move</p>
+      <div className="moveName">{ move.moveName }</div>
+    </div>
+      <div className="itemCount">
+     <div className="itemCount__count">{ move.totalItemsCount }</div>
+     <div>Items</div>
+    </div>
+    <div className="moveValue">
+     <p>Value</p>
+     <div className="move__value">${ move.totalItemsValue }</div>
+    </div>
+
+    <div className="lowerRow">
+
+    <div className="fragile">
+     <p>Fragile</p>
+     <div className="checkBox">{ move.isFragile ? "X" : ""}</div>
+    </div>
+     <Link to={`/moves/${move.id}`}>
+      <button id={`btn--edit-${move.id}`} className="move__linkBtn--edit">Edit</button>
+     </Link>
+     <Link to="/">
+      <button id={`btn--delete-${move.id}`} className="move__linkBtn--delete">Delete</button>
+     </Link>
+    </div> 
+  </section>
+ )
+}

--- a/src/components/moves/moveList.css
+++ b/src/components/moves/moveList.css
@@ -1,0 +1,22 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  border: 1px solid black;
+}
+
+.moveSummaryList {
+  padding: 0.5em;
+}
+
+.moveSummaryList__header {
+  background: pink;
+  text-align: center;
+}

--- a/src/components/moves/moveSummary.css
+++ b/src/components/moves/moveSummary.css
@@ -1,0 +1,90 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  text-decoration: none;
+  list-style: none;
+  overflow-wrap: break-word;
+
+  border: 1px solid red;
+}
+
+.moveSummary {
+  border: 2px solid green;
+  background: lightsalmon;
+  text-align: center;
+  margin-top: 10px;
+
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+}
+
+.moveName,
+.moveValue,
+.lowerRow {
+  grid-column-start: 3;
+  grid-column-end: 6;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5em;
+}
+
+.boxCount,
+.itemCount {
+  grid-column-start: 1;
+  grid-column-end: 3;
+  background: lightgreen;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+/* .lowerRow {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+} */
+
+.fragile {
+  display: flx;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5em;
+  grid-column-start: 3;
+  grid-column-end: 4;
+}
+
+.boxCount__count,
+.itemCount__count {
+  height: 20px;
+  width: 20px;
+  background: white;
+  padding: 0.2em;
+}
+
+.count__items {
+  background: white;
+  height: 20px;
+  width: 20px;
+  padding: 2px;
+}
+
+.move__linkBtn--edit,
+.move__linkBtn--delete {
+  padding: 0.2em;
+  width: 70px;
+}
+
+.move__linkBtn--edit {
+  background: lightgreen;
+}
+
+.move__linkBtn--delete {
+  margin-left: 1em;
+  background: salmon;
+}

--- a/src/components/summary/Summary.jsx
+++ b/src/components/summary/Summary.jsx
@@ -4,14 +4,14 @@ import { Link } from "react-router-dom"
 import "./summary.css"
 
 
-export const Summary = ({ data } ) => {
+export const Summary = ({ listType }) => {
 
  return (
   <section className="summary">
-   <div className="summary__dataLength">{ data.collection.length }</div>
+   <div className="summary__dataLength">{ listType.data.collection.length }</div>
    <div className="summary__buttons">
-    <h2 className="summary__moveType">{ data.type }</h2>
-    <Link to="/"><button className="summary__linkBtn--view" >View</button></Link>
+    <h2 className="summary__moveType">{ listType.data.type }</h2>
+    <Link to={`/${listType.data.type}`}><button className="summary__linkBtn--view" >View</button></Link>
     <Link to="/"><button className="summary__linkBtn--edit" >Edit</button></Link>
     <Link to="/"><button className="summary__linkBtn--delete" >Delete</button></Link>
    </div>

--- a/src/components/summary/SummaryList.jsx
+++ b/src/components/summary/SummaryList.jsx
@@ -35,14 +35,14 @@ export const SummaryList = ({ loggedInUserId }) => {
     collection: items.filter(item => boxesData.collection.find(box => item.boxId === box.id))
   }
   
-  const loggedInUserName = moves.find(move => move.userId === loggedInUserId)
+  const loggedInUser= moves.find(move => move.userId === loggedInUserId)
   const dataToRender = [movesData, boxesData, itemsData]
 
   return (
     <div className="summaryList">
-      <h1 className="summaryList__header">{ loggedInUserName?.user.username }'s Summary</h1>
+      <h1 className="summaryList__header">{ loggedInUser?.user.username }'s Summary</h1>
       {
-        dataToRender.map((payload, i) => <Summary key={i} data={payload} />)
+        dataToRender.map((data, i) => <Summary key={i} listType={{ data }} />)
       }
     </div>
   )


### PR DESCRIPTION
# Description

User can view a summary of their total moves, boxes, items as a list view.

Fixes # 63
Closes #63 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout cr-navigation-listViews`
`npm start`

In another tab, cd into `api` and run

`json-server -p 8088 -w database.json`

From user summary page, you can navigate to moves, boxes, items summary list by clicking their respective `View` button.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works
	
