### PR TITLE
feat: user can add item image to item detail page through remote imag…

### DIFF
--- a/src/components/items/ItemSummary.jsx
+++ b/src/components/items/ItemSummary.jsx
@@ -19,7 +19,11 @@ export const ItemSummary = ({ item } ) => {
 
  return (
   <section className={styles.summary}>
-    <img className={styles.summary__image} src="https://unsplash.com/photos/nP9WOiM41WE" alt="QR code place holder" />
+    <div className={styles.summary__image_summary}>
+      { item.imagePath && (
+        <img className={styles.summary__image} src={item.imagePath} alt="User-defined image" />
+      )}
+    </div>
 
     <fieldset className={styles.move__checkbox}>
       <label className={styles.move__checkboxLabel} htmlFor="summaryMove">Move</label>

--- a/src/components/items/itemDetail.module.css
+++ b/src/components/items/itemDetail.module.css
@@ -16,12 +16,15 @@
 .container__image_container {
   height: 40%;
   width: 90%;
+  margin: 0 auto;
   margin-bottom: 10px;
+  background: var(--tricery-color);
 }
 
 .container__image {
   display: block;
   height: 100%;
+  width: 100%;
   margin: 0 auto;
 }
 
@@ -81,7 +84,8 @@
 .container__btn__camera,
 .container__btn__submit,
 .container__btn__delete,
-.fragile__checkbox {
+.fragile__checkbox,
+.cameraLabel {
   border-radius: 10px;
   padding: 0.2em;
 }
@@ -94,7 +98,8 @@
   justify-content: space-between;
 }
 
-.container__btn__camera {
+.container__btn__camera,
+.cameraLabel {
   grid-column-start: 5;
   grid-column-end: 7;
 }
@@ -109,4 +114,26 @@
   grid-column-start: 11;
   grid-column-end: 13;
   background: salmon;
+}
+
+/*
+  Make the input look like a button and hide "select file" dialog box.
+*/
+/* .cameraLabel {
+  background: var(--secondary-color);
+  display: block;
+  display: flex;
+  align-items: center;
+} */
+
+/* .container__btn__camera {
+  display: none;
+} */
+
+.imgInputFile {
+  display: none;
+}
+
+.container__btn__camera {
+  border: 1px solid var(--tricery-color);
 }

--- a/src/components/items/itemSummary.module.css
+++ b/src/components/items/itemSummary.module.css
@@ -8,13 +8,18 @@
   border-bottom: 5px dashed black;
 }
 
-.summary__image {
+.summary__image_summary {
   grid-column-start: 1;
   grid-column-end: 4;
   grid-row-start: 1;
   grid-row-end: 3;
-  /* background: red; */
+  background: var(--tricery-color);
   border: 2px solid black;
+}
+
+.summary__image {
+  height: 100%;
+  width: 100%;
 }
 
 .move__checkbox,
@@ -26,16 +31,6 @@
   justify-content: space-between;
   align-items: center;
 }
-
-/* .move__checkboxLabel,
-.box__checkboxLabel,
-.fragile__checkboxLabel {
-  margin-left: 5px;
-}
-
-.formControl {
-  margin-right: 5px;
-} */
 
 .move__checkbox,
 .summary__description,
@@ -104,90 +99,3 @@
   padding: 1em;
   text-align: center;
 }
-
-/* .itemSummary {
-  border: 2px solid blue;
-  background: lightsalmon;
-  text-align: center;
-  justify-content: space-between;
-  margin-top: 10px;
-
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  grid-template-rows: repeat(3, 1fr);
-}
-
-.itemSummary__image {
-  border: 1px solid green;
-  grid-column-start: 1;
-  grid-column-end: 2;
-  grid-row-start: 1;
-  grid-row-end: 3;
-}
-
-.description,
-.value,
-.summary__btns {
-  grid-column-start: 3;
-  grid-column-end: 6;
-}
-
-.move,
-.box,
-.fragile {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5em;
-  grid-column-start: 2;
-  grid-column-end: 3;
-}
-
-.fragile {
-  grid-column-start: 1;
-  grid-column-end: 2;
-  grid-row-start: 4;
-  grid-row-end: 5;
-}
-
-.description,
-.value {
-  display: flex;
-  justify-content: space-between;
-  padding: 0.5em;
-  text-align: left;
-}
-
-.description__text,
-.description__value {
-  flex-basis: 60%;
-}
-
-.checkBox {
-  height: 10px;
-  width: 10px;
-  background: white;
-  padding: 0.2em;
-}
-
-.summary__btns {
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  border: 2px solid red;
-}
-
-.summary__linkBtn--edit,
-.summary__linkBtn--delete {
-  padding: 0.2em;
-  width: 80px;
-}
-
-.summary__linkBtn--edit {
-  background: lightgreen;
-}
-
-.summary__linkBtn--delete {
-  margin-left: 1em;
-  background: salmon;
-} */


### PR DESCRIPTION
# Description

Set up Cloudinary remote image hosting.

 User can add item image to item detail page through remote image hosting.

Closes #31 
Closes #22 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout cr-streach-capture-image`
`npm start`

In another tab, cd into `api` and run

`json-server 8088  database.json`

1. Create Move
2. Create Box and link to Move above.
3. Create Item and link to Box above.
4. In Item list view, chick `Edit`.
5. Click `Camera` and select an image.
6. Click `Update`.
7. Image should render i the green box. Please note, larger images will take some time to load.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works
	
